### PR TITLE
add standalone build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+
+llvm-cxxapi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,54 @@
-set(LLVM_LINK_COMPONENTS
-  Core
-  Support
-  BitReader
-  IRReader
-  )
+cmake_minimum_required(VERSION 3.4.3)
 
-add_llvm_tool(llvm-cxxapi
-  CxxApiWriterPass.cpp
-  llvm-cxxapi.cpp
-  )
+if(NOT COMMAND add_llvm_loadable_module)
+    if (DEFINED ENV{LLVM_DIR})
+        # We need to match the build environment for LLVM:
+        # In particular, we need C++11 and the -fno-rtti flag
+        set(CMAKE_CXX_STANDARD 11)
+	if(CMAKE_BUILD_TYPE MATCHES "Debug")
+		set(CMAKE_CXX_FLAGS "-std=gnu++11 -O0 -fno-rtti")
+	else()
+		set(CMAKE_CXX_FLAGS "-std=gnu++11 -O3 -fno-rtti")
+	endif()
+
+	find_package(LLVM REQUIRED CONFIG)
+        
+        list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+        include(AddLLVM)
+
+        add_definitions(${LLVM_DEFINITIONS})
+        include_directories(${LLVM_INCLUDE_DIRS})
+
+	# map lib names
+	# llvm_map_components_to_libnames(llvm_libs bitreader bitwriter core ipo irreader instcombine instrumentation target linker analysis scalaropts support )
+	llvm_map_components_to_libnames(llvm_libs core support bitreader irreader)
+	# build target
+	add_executable(llvm-cxxapi CxxApiWriterPass.cpp llvm-cxxapi.cpp)
+	target_link_libraries(llvm-cxxapi ${llvm_libs})
+
+
+    else()
+        message(FATAL_ERROR "\
+WARNING: The LLVM_DIR var was not set (required for an out-of-source build)!\n\
+Please set this to environment variable to point to the LLVM build directory\
+(e.g. on linux: export LLVM_DIR=/path/to/llvm/build/dir)")
+    endif()
+else()
+
+	set(LLVM_CXXAPI_IN_SOURCE_BUILD 1)
+
+    set(LLVM_LINK_COMPONENTS
+      Core
+      Support
+      BitReader
+      IRReader
+      )
+    
+    add_llvm_tool(llvm-cxxapi
+      CxxApiWriterPass.cpp
+      llvm-cxxapi.cpp
+    )
+endif()
+
+install(TARGETS llvm-cxxapi
+	DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,14 +2,6 @@ cmake_minimum_required(VERSION 3.4.3)
 
 if(NOT COMMAND add_llvm_loadable_module)
     if (DEFINED ENV{LLVM_DIR})
-        # We need to match the build environment for LLVM:
-        # In particular, we need C++11 and the -fno-rtti flag
-        set(CMAKE_CXX_STANDARD 11)
-	if(CMAKE_BUILD_TYPE MATCHES "Debug")
-		set(CMAKE_CXX_FLAGS "-std=gnu++11 -O0 -fno-rtti")
-	else()
-		set(CMAKE_CXX_FLAGS "-std=gnu++11 -O3 -fno-rtti")
-	endif()
 
 	find_package(LLVM REQUIRED CONFIG)
         

--- a/CxxApiWriterPass.cpp
+++ b/CxxApiWriterPass.cpp
@@ -16,7 +16,11 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/StringExtras.h"
+#if defined(LLVM_CXXAPI_IN_SOURCE_BUILD)
 #include "llvm/Config/config.h"
+#else
+#include "llvm/Config/llvm-config.h"
+#endif
 #include "llvm/IR/CallingConv.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DerivedTypes.h"


### PR DESCRIPTION
With this commit, there is no longer a need to build LLVM manually but
can use a standalone build by export LLVM_DIR. The path to LLVM_DIR
should be set to the one that contains the directory "cmake". For
example, when llvm-6.0 deb package (latest version available on
https://apt.llvm.org/) is installed on Ubuntu 16.04/18.04, the build
process can be:

    export LLVM_DIR=/usr/lib/llvm-6.0/lib
    cmake .
    make

Installation is possible via `sudo make install`
(destination /usr/local/bin/llvm-cxxapi)